### PR TITLE
Propagate social exceptions as auth denied response instead of crashing

### DIFF
--- a/rest_framework_social_oauth2/oauth2_grants.py
+++ b/rest_framework_social_oauth2/oauth2_grants.py
@@ -11,7 +11,7 @@ from oauthlib.oauth2.rfc6749.grant_types.refresh_token import RefreshTokenGrant
 
 from social.apps.django_app.views import NAMESPACE
 from social.apps.django_app.utils import load_backend, load_strategy
-from social.exceptions import MissingBackend
+from social.exceptions import MissingBackend, SocialAuthBaseException
 from social.utils import requests
 
 
@@ -94,6 +94,8 @@ class SocialTokenGrant(RefreshTokenGrant):
                 description="Backend responded with HTTP{0}: {1}.".format(e.response.status_code,
                                                                           e.response.text),
                 request=request)
+        except SocialAuthBaseException as e:
+            raise errors.AccessDeniedError(description=str(e), request=request)
 
         if not user:
             raise errors.InvalidGrantError('Invalid credentials given.', request=request)


### PR DESCRIPTION
**python-social-auth** may raise authentication-related exceptions while executing the pipeline.
For example, an `InvalidEmail` exception may be raised in the mail pipeline.

This used to result in a crash handled by generic last-resort error 500 handler. This patch
handles all authentication errors raised inside the pipeline and signals them nicely in a
401 Access Denied response which includes the error description.

In the case of the aforementioned `InvalidEmail` exception this will be returned as a response:
`{"error_description":"Email couldn't be validated","error":"access_denied"}`