### PR TITLE
Fix ImportError: No module named 'social_django'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         'djangorestframework>=3.0.1',
         'django-oauth-toolkit>=0.9.0',
-        'python-social-auth>=0.2.2'
+        'python-social-auth==0.2.2'
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Because not compatible with new version of python-social-auth.