### PR TITLE
:heavy_plus_sign: Add django-braces dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     install_requires=[
         'djangorestframework>=3.0.1',
         'django-oauth-toolkit>=1.0.0',
-        'social-auth-app-django>=0.1.0'
+        'social-auth-app-django>=0.1.0',
+        'django-braces>=1.11.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
django-oauth-toolkit says "The dependency on django-braces has been dropped" and this lib use it.